### PR TITLE
Update Chevrolet Tahoe generations: add Wikipedia references and README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Chevrolet Tahoe
 
+This repository contains signal set configurations for the Chevrolet Tahoe, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Chevrolet Tahoe.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Chevrolet_Tahoe"
+
 generations:
   - name: "First Generation (GMT400)"
     start_year: 1995


### PR DESCRIPTION
- Added references array with Wikipedia article link to generations.yaml
- Updated README.md with standard documentation template
- Verified generation data accuracy against Wikipedia article (5 generations, dates 1995-present)
- Generation information is accurate: GMT400 (1995-1999), GMT800 (2000-2006), GMT900 (2007-2014), K2XX (2015-2020), T1XX (2021-present)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
